### PR TITLE
Opportunity form error copy change #171

### DIFF
--- a/public/locales/de/translations.json
+++ b/public/locales/de/translations.json
@@ -40,7 +40,7 @@
   "form": {
     "error": {
       "required": "Dieses Feld ist erforderlich",
-      "postcode": "Muss eine gültige Postleitzahl von Berlin sein",
+      "postcode": "Bitte nur die PLZ eintragen (keine Buchstaben, nur Zahlen)",
       "email": "Muss eine gültige E-Mail-Adresse sein",
       "badEmail": "Keine gültige Betreiber E-Mail",
       "location": "Bitte wähle mindestens einen Standort aus",


### PR DESCRIPTION
The copy change is done by replacing the error text.

closes #171 