### PR TITLE
fix testimonials behaviour

### DIFF
--- a/src/components/core/paginatedCards/PaginatedCards.tsx
+++ b/src/components/core/paginatedCards/PaginatedCards.tsx
@@ -36,7 +36,7 @@ export function PaginatedCards({
   const visibleCards = cards.slice(startIndex, endIndex);
 
   const nextCardElement = cards[endIndex];
-  const shouldShowNavigation = totalPages > 1;
+  const showNavigation = totalPages > 1;
 
   const goToPage = (pageNumber: number) => {
     setCurrentPage(pageNumber);
@@ -51,7 +51,7 @@ export function PaginatedCards({
       id="paginated-cards-container"
       {...{ onTouchStart, onTouchEnd }}
     >
-      {shouldShowNavigation && (
+      {showNavigation && (
         <ArrowButtons
           currentIndex={currentPage}
           lastIndex={totalPages - 1}
@@ -77,7 +77,7 @@ export function PaginatedCards({
         </VisibleCardsContainer>
       )}
 
-      {shouldShowNavigation && (
+      {showNavigation && (
         <PaginationIndicators
           currentPage={currentPage}
           totalPages={totalPages}

--- a/src/components/core/paginatedCards/PaginatedCards.tsx
+++ b/src/components/core/paginatedCards/PaginatedCards.tsx
@@ -36,6 +36,7 @@ export function PaginatedCards({
   const visibleCards = cards.slice(startIndex, endIndex);
 
   const nextCardElement = cards[endIndex];
+  const shouldShowNavigation = totalPages > 1;
 
   const goToPage = (pageNumber: number) => {
     setCurrentPage(pageNumber);
@@ -50,12 +51,14 @@ export function PaginatedCards({
       id="paginated-cards-container"
       {...{ onTouchStart, onTouchEnd }}
     >
-      <ArrowButtons
-        currentIndex={currentPage}
-        lastIndex={totalPages - 1}
-        setCurrentIndex={setCurrentPage}
-        color={arrowButtonColor}
-      />
+      {shouldShowNavigation && (
+        <ArrowButtons
+          currentIndex={currentPage}
+          lastIndex={totalPages - 1}
+          setCurrentIndex={setCurrentPage}
+          color={arrowButtonColor}
+        />
+      )}
 
       {isOverlayingCards ? (
         <OverlayingVisibleCardsContainer id="overlaying-visible-cards-container">
@@ -74,13 +77,15 @@ export function PaginatedCards({
         </VisibleCardsContainer>
       )}
 
-      <PaginationIndicators
-        currentPage={currentPage}
-        totalPages={totalPages}
-        indicatorColor={bottomIndicatorColor}
-        currentIndicatorColor={bottomCurrentIndicatorColor}
-        goToPage={goToPage}
-      />
+      {shouldShowNavigation && (
+        <PaginationIndicators
+          currentPage={currentPage}
+          totalPages={totalPages}
+          indicatorColor={bottomIndicatorColor}
+          currentIndicatorColor={bottomCurrentIndicatorColor}
+          goToPage={goToPage}
+        />
+      )}
     </PaginatedCardsContainer>
   );
 }


### PR DESCRIPTION
- When there is no Testimonials, we will be hiding the arrows and pagination in carousel slider.
- When the total page size is > 1 then only we will enable and make arrows and carousel slider otherwise it will be hidden, this is for better user intaction to not confuse them.

closes #56 
